### PR TITLE
Add utf-8 encoding for reading test.txt

### DIFF
--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ from finglish import f2p
 def main():
     print('Loading test cases...')
 
-    with open('test.txt') as f:
+    with open('test.txt' , encoding="utf-8") as f:
         pairs = [l.strip().split(' ', 1) for l in f if l.strip()]
 
     print('{} test cases loaded.'.format(len(pairs)))


### PR DESCRIPTION
When I ran `test.py` I got this error :
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 255: character maps to <undefined>
```
And it is caused by using non-ASCII characters like Persian characters